### PR TITLE
Added material property animation via KHR_animation_pointer

### DIFF
--- a/src/app/worker.ts
+++ b/src/app/worker.ts
@@ -191,11 +191,11 @@ async function initWorker(
   world.addComponent(cameraEntity, new MainCameraTagComponent());
 
   // Scene Lighting and Fog - Lighter fog to better see the demoModel
-  world.addResource(new SceneLightingComponent());
-  const sceneLighting = world.getResource(SceneLightingComponent)!;
-  sceneLighting.ambientColor.set([0.4, 0.42, 0.5, 1.0]);
-  sceneLighting.fogColor.set([0.8, 0.85, 0.9, 1.0]); // Light blue-gray
-  sceneLighting.fogParams0.set([0.01, 0.0, 0.0, 1.0]); // Very light fog
+  //world.addResource(new SceneLightingComponent());
+  //const sceneLighting = world.getResource(SceneLightingComponent)!;
+  //sceneLighting.ambientColor.set([0.4, 0.42, 0.5, 1.0]);
+  //sceneLighting.fogColor.set([0.8, 0.85, 0.9, 1.0]); // Light blue-gray
+  //sceneLighting.fogParams0.set([0.01, 0.0, 0.0, 1.0]); // Very light fog
 
   /*
   // Ground Plane - Darker to contrast with demoModel
@@ -241,21 +241,29 @@ async function initWorker(
     console.error("Failed to load model:", error);
     // Fallback: create a simple sphere
     demoModelEntity = world.createEntity();
-    const fallbackMaterial = await resourceManager.createPBRMaterial({
-      albedo: [0.8, 0.6, 0.4, 1],
+    const fallbackOptions = {
+      albedo: [0.8, 0.6, 0.4, 1] as [number, number, number, number],
       metallic: 0.1,
       roughness: 0.3,
-    });
+    };
+    const fallbackTemplate =
+      await resourceManager.createPBRMaterialTemplate(fallbackOptions);
+    const fallbackInstance = await resourceManager.createPBRMaterialInstance(
+      fallbackTemplate,
+      fallbackOptions,
+    );
+
     const sphereMesh = await resourceManager.createMesh(
       "fallback_sphere",
       createIcosphereMeshData(1.0, 3),
     );
     const demoModelTransform = new TransformComponent();
     demoModelTransform.setPosition(0, 0, 0);
+    demoModelTransform.setScale(1, 1, 1);
     world.addComponent(demoModelEntity, demoModelTransform);
     world.addComponent(
       demoModelEntity,
-      new MeshRendererComponent(sphereMesh, fallbackMaterial),
+      new MeshRendererComponent(sphereMesh, fallbackInstance),
     );
   }
 
@@ -264,18 +272,39 @@ async function initWorker(
     "light_sphere",
     createIcosphereMeshData(0.05, 2),
   );
-  const lightMaterialWhite = await resourceManager.createPBRMaterial({
-    albedo: [1, 1, 1, 1],
-    emissive: [1, 1, 1],
-  });
-  const lightMaterialWarm = await resourceManager.createPBRMaterial({
-    albedo: [1, 0.8, 0.6, 1],
-    emissive: [1, 0.8, 0.6],
-  });
-  const lightMaterialCool = await resourceManager.createPBRMaterial({
-    albedo: [0.6, 0.8, 1, 1],
-    emissive: [0.6, 0.8, 1],
-  });
+
+  const whiteOptions = {
+    albedo: [1, 1, 1, 1] as [number, number, number, number],
+    emissive: [1, 1, 1] as [number, number, number],
+  };
+  const whiteTemplate =
+    await resourceManager.createPBRMaterialTemplate(whiteOptions);
+  const lightMaterialWhite = await resourceManager.createPBRMaterialInstance(
+    whiteTemplate,
+    whiteOptions,
+  );
+
+  const warmOptions = {
+    albedo: [1, 0.8, 0.6, 1] as [number, number, number, number],
+    emissive: [1, 0.8, 0.6] as [number, number, number],
+  };
+  const warmTemplate =
+    await resourceManager.createPBRMaterialTemplate(warmOptions);
+  const lightMaterialWarm = await resourceManager.createPBRMaterialInstance(
+    warmTemplate,
+    warmOptions,
+  );
+
+  const coolOptions = {
+    albedo: [0.6, 0.8, 1, 1] as [number, number, number, number],
+    emissive: [0.6, 0.8, 1] as [number, number, number],
+  };
+  const coolTemplate =
+    await resourceManager.createPBRMaterialTemplate(coolOptions);
+  const lightMaterialCool = await resourceManager.createPBRMaterialInstance(
+    coolTemplate,
+    coolOptions,
+  );
 
   // Key Light (main light)
   keyLightEntity = world.createEntity();

--- a/src/core/ecs/components/meshRendererComponent.ts
+++ b/src/core/ecs/components/meshRendererComponent.ts
@@ -1,11 +1,11 @@
 // src/core/ecs/components/meshRendererComponent.ts
-import { Material } from "@/core/materials/material";
+import { MaterialInstance } from "@/core/materials/materialInstance";
 import { Mesh } from "@/core/types/gpu";
 import { IComponent } from "../component";
 
 export class MeshRendererComponent implements IComponent {
   public mesh: Mesh;
-  public material: Material;
+  public material: MaterialInstance;
 
   // per-mesh shadow flags
   public castShadows = true;
@@ -14,13 +14,13 @@ export class MeshRendererComponent implements IComponent {
   /**
    * Creates a mesh renderer component.
    * @param mesh The mesh to render.
-   * @param material The material to use.
+   * @param material The material instance to use.
    * @param castShadows Whether this object casts shadows.
    * @param receiveShadows Whether this object receives shadows.
    */
   constructor(
     mesh: Mesh,
-    material: Material,
+    material: MaterialInstance,
     castShadows = true,
     receiveShadows = true,
   ) {

--- a/src/core/ecs/components/skyboxComponent.ts
+++ b/src/core/ecs/components/skyboxComponent.ts
@@ -1,5 +1,5 @@
 // src/core/ecs/components/skyboxComponent.ts
-import { SkyboxMaterial } from "@/core/materials/skyboxMaterial";
+import { MaterialInstance } from "@/core/materials/materialInstance";
 import { IComponent } from "../component";
 
 /**
@@ -7,9 +7,9 @@ import { IComponent } from "../component";
  * It's typically added as a resource to the world.
  */
 export class SkyboxComponent implements IComponent {
-  public material: SkyboxMaterial;
+  public material: MaterialInstance;
 
-  constructor(material: SkyboxMaterial) {
+  constructor(material: MaterialInstance) {
     this.material = material;
   }
 }

--- a/src/core/materials/material.ts
+++ b/src/core/materials/material.ts
@@ -7,8 +7,6 @@ export class Material {
   public readonly id: number;
   /** A cache for pipelines, keyed by mesh layouts. */
   protected pipelineCache = new Map<string, GPURenderPipeline>();
-  /** The bind group containing resources specific to this material (textures, uniforms). */
-  public bindGroup: GPUBindGroup;
   /** Does the material require alpha blending. */
   public isTransparent: boolean;
   public shader: Shader;
@@ -20,14 +18,12 @@ export class Material {
     device: GPUDevice,
     shader: Shader,
     layout: GPUBindGroupLayout,
-    bindGroup: GPUBindGroup,
     isTransparent = false,
   ) {
     this.id = Material.nextId++;
     this.device = device;
     this.shader = shader;
     this.materialBindGroupLayout = layout;
-    this.bindGroup = bindGroup;
     this.isTransparent = isTransparent;
   }
 
@@ -93,19 +89,6 @@ export class Material {
         expectedLocations.add(attr.shaderLocation);
       }
     }
-
-    // Log the vertex state configuration for debugging
-    console.log(`[Material ${this.id}] Creating pipeline with vertex state:`);
-    for (let i = 0; i < meshLayouts.length; i++) {
-      const layout = meshLayouts[i];
-      const locations = layout.attributes
-        .map((a) => `@location(${a.shaderLocation})`)
-        .join(", ");
-      console.log(
-        `  Buffer ${i}: stride=${layout.arrayStride}, locations=[${locations}]`,
-      );
-    }
-    console.log(`  Buffer ${meshLayouts.length}: Instance data`);
 
     const pipelineLayout = this.device.createPipelineLayout({
       bindGroupLayouts: [

--- a/src/core/materials/materialInstance.ts
+++ b/src/core/materials/materialInstance.ts
@@ -1,0 +1,78 @@
+// src/core/materials/materialInstance.ts
+import { Material } from "./material";
+
+/**
+ * Represents a unique instance of a material.
+ * It holds instance-specific data like the uniform buffer and bind group,
+ * while referencing a shared Material object for the shader, layout, and pipeline.
+ */
+export class MaterialInstance {
+  private static nextId = 0;
+  public readonly id: number;
+
+  public readonly material: Material;
+  public readonly uniformBuffer: GPUBuffer;
+  public readonly bindGroup: GPUBindGroup;
+
+  private device: GPUDevice;
+
+  // A map from a glTF property path to a function that updates the uniform buffer.
+  private uniformUpdaters = new Map<string, (value: Float32Array) => void>();
+
+  constructor(
+    device: GPUDevice,
+    material: Material,
+    uniformBuffer: GPUBuffer,
+    bindGroup: GPUBindGroup,
+  ) {
+    this.id = MaterialInstance.nextId++;
+    this.device = device;
+    this.material = material;
+    this.uniformBuffer = uniformBuffer;
+    this.bindGroup = bindGroup;
+  }
+
+  /**
+   * Registers a function that knows how to update a specific part of the uniform buffer.
+   * @param propertyPath The property path (e.g., "pbrMetallicRoughness/baseColorFactor").
+   * @param byteOffset The byte offset within the uniform buffer to write to.
+   * @param sizeInFloats The number of float32 values to write.
+   */
+  public registerUniformUpdater(
+    propertyPath: string,
+    byteOffset: number,
+    sizeInFloats: number,
+  ): void {
+    this.uniformUpdaters.set(propertyPath, (value: Float32Array) => {
+      if (value.length < sizeInFloats) {
+        console.warn(
+          `Uniform update for "${propertyPath}" expected ${sizeInFloats} floats, got ${value.length}`,
+        );
+        return;
+      }
+      this.device.queue.writeBuffer(
+        this.uniformBuffer,
+        byteOffset,
+        value.buffer,
+        value.byteOffset,
+        sizeInFloats * 4,
+      );
+    });
+  }
+
+  /**
+   * Updates a named uniform property for this material instance.
+   * This performs a partial write to the GPU uniform buffer.
+   * @param propertyPath The property to update (e.g., "pbrMetallicRoughness/baseColorFactor").
+   * @param value The new value as a Float32Array.
+   */
+  public updateUniform(propertyPath: string, value: Float32Array): void {
+    const updater = this.uniformUpdaters.get(propertyPath);
+    if (updater) {
+      updater(value);
+    } else {
+      // This can happen if the model animates a property we haven't mapped.
+      // console.warn(`No uniform updater registered for path: ${propertyPath}`);
+    }
+  }
+}

--- a/src/core/materials/unlitGroundMaterial.ts
+++ b/src/core/materials/unlitGroundMaterial.ts
@@ -5,10 +5,12 @@ import { Shader } from "@/core/shaders/shader";
 import { ShaderPreprocessor } from "../shaders/preprocessor";
 import { UnlitGroundMaterialOptions } from "../types/gpu";
 import { createGPUBuffer } from "../utils/webgpu";
+import { MaterialInstance } from "./materialInstance";
 
 export class UnlitGroundMaterial extends Material {
   private static shader: Shader | null = null;
   private static layout: GPUBindGroupLayout | null = null;
+  private static template: UnlitGroundMaterial | null = null;
 
   public static async initialize(
     device: GPUDevice,
@@ -20,13 +22,13 @@ export class UnlitGroundMaterial extends Material {
       device,
       preprocessor,
       unlitGroundShaderUrl,
-      "UNLIT_SKYBOX_SHADER",
+      "UNLIT_GROUND_SHADER",
       "vs_main",
       "fs_main",
     );
 
     this.layout = device.createBindGroupLayout({
-      label: "UNLIT_SKYBOX_MATERIAL_BIND_GROUP_LAYOUT",
+      label: "UNLIT_GROUND_MATERIAL_BIND_GROUP_LAYOUT",
       entries: [
         { binding: 0, visibility: GPUShaderStage.FRAGMENT, texture: {} },
         { binding: 1, visibility: GPUShaderStage.FRAGMENT, sampler: {} },
@@ -39,18 +41,31 @@ export class UnlitGroundMaterial extends Material {
     });
   }
 
-  constructor(
-    device: GPUDevice,
-    options: UnlitGroundMaterialOptions,
-    texture: GPUTexture,
-    sampler: GPUSampler,
-  ) {
+  private constructor(device: GPUDevice) {
     if (!UnlitGroundMaterial.shader || !UnlitGroundMaterial.layout) {
       throw new Error(
         "UnlitGroundMaterial not initialized. Call UnlitGroundMaterial.initialize() first.",
       );
     }
+    // Unlit ground is never transparent
+    super(
+      device,
+      UnlitGroundMaterial.shader,
+      UnlitGroundMaterial.layout,
+      false,
+    );
+  }
 
+  public static getTemplate(device: GPUDevice): UnlitGroundMaterial {
+    this.template ??= new UnlitGroundMaterial(device);
+    return this.template;
+  }
+
+  public createInstance(
+    options: UnlitGroundMaterialOptions,
+    texture: GPUTexture,
+    sampler: GPUSampler,
+  ): MaterialInstance {
     // Create uniform buffer
     const uniformData = new Float32Array(8); // 2x vec4
     const color = options.color ?? [1, 1, 1, 1];
@@ -59,15 +74,15 @@ export class UnlitGroundMaterial extends Material {
     uniformData[4] = useTexture;
 
     const uniformBuffer = createGPUBuffer(
-      device,
+      this.device,
       uniformData,
       GPUBufferUsage.UNIFORM,
-      "UNLIT_SKYBOX_MATERIAL_UNIFORMS",
+      "UNLIT_GROUND_MATERIAL_UNIFORMS",
     );
 
-    const bindGroup = device.createBindGroup({
-      label: "UNLIT_SKYBOX_MATERIAL_BIND_GROUP",
-      layout: UnlitGroundMaterial.layout,
+    const bindGroup = this.device.createBindGroup({
+      label: "UNLIT_GROUND_MATERIAL_INSTANCE_BIND_GROUP",
+      layout: this.materialBindGroupLayout,
       entries: [
         { binding: 0, resource: texture.createView() },
         { binding: 1, resource: sampler },
@@ -75,12 +90,6 @@ export class UnlitGroundMaterial extends Material {
       ],
     });
 
-    super(
-      device,
-      UnlitGroundMaterial.shader,
-      UnlitGroundMaterial.layout,
-      bindGroup,
-      false,
-    );
+    return new MaterialInstance(this.device, this, uniformBuffer, bindGroup);
   }
 }

--- a/src/core/types/animation.ts
+++ b/src/core/types/animation.ts
@@ -1,71 +1,41 @@
 // src/core/types/animation.ts
 
 import { Entity } from "@/core/ecs/entity";
+import { ComponentConstructor } from "@/core/ecs/component";
 
-/**
- * The interpolation method to use between keyframes.
- * - `LINEAR`: Linear interpolation. For quaternions, this implies Spherical
- *   Linear Interpolation (SLERP).
- * - `STEP`: No interpolation; the value of the previous keyframe is held
- *   until the next keyframe.
- * - `CUBICSPLINE`: Cubic spline interpolation. The `values` array will
- *   contain triplets of [in-tangent, value, out-tangent].
- */
 export type AnimationInterpolation = "LINEAR" | "STEP" | "CUBICSPLINE";
 
 /**
- * The property of a TransformComponent that an animation channel targets.
+ * Defines the target property of an animation channel.
+ * For transforms, property is "translation", "rotation", or "scale".
+ * For materials, it's a glTF JSON Pointer path like "pbrMetallicRoughness/baseColorFactor".
  */
-export type AnimationPath = "translation" | "rotation" | "scale";
+export interface AnimationPath {
+  component: ComponentConstructor;
+  property: string;
+}
 
-/**
- * Stores keyframe data for a single animated property (ex: translation).
- * This is a runtime representation of a glTF animation sampler.
- */
 export interface AnimationSampler {
-  /**
-   * An array of keyframe timestamps, in seconds. Each time corresponds to a
-   * value in the "values" array. The array must be strictly increasing.
-   */
+  // Keyframe times in seconds (strictly increasing)
   times: Float32Array;
-  /**
-   * A flattened array of keyframe values. The layout depends on the `path`
-   * and `interpolation` method. For example, for a `rotation` path with
-   * `LINEAR` interpolation, this will be a sequence of quaternions
-   * `[x, y, z, w, x, y, z, w, ...]`.
-   */
+  // Flattened values array:
+  // - translation/scale: vec3 (stride 3)
+  // - rotation: quat (stride 4)
+  // - CUBICSPLINE (not fully implemented yet): [inTangent, value, outTangent] per key
   values: Float32Array;
-  /** The interpolation method to use between keyframes. */
   interpolation: AnimationInterpolation;
-  /**
-   * The number of floats that represent a single keyframe's value.
-   * For example, 3 for `translation` (vec3), 4 for `rotation` (quat).
-   */
+  // Number of floats per output "value": 3 for vec3, 4 for quat
   valueStride: number;
 }
 
-/**
- * Connects an animation sampler to a specific property of a target entity.
- * This is a runtime representation of a glTF animation channel.
- */
 export interface AnimationChannel {
-  /** The entity whose `TransformComponent` will be modified by this channel. */
-  targetEntity: Entity;
-  /** Which property of the transform (`translation`, `rotation`, or `scale`) to modify. */
-  path: AnimationPath;
-  /** The sampler containing the keyframe data for this channel. */
-  sampler: AnimationSampler;
+  targetEntity: Entity; // The entity whose component to drive
+  path: AnimationPath; // Which component and property this channel modifies
+  sampler: AnimationSampler; // Keyframe sampler
 }
 
-/**
- * A collection of animation channels that together define a complete animation.
- * This is a runtime representation of a glTF animation.
- */
 export interface AnimationClip {
-  /** The name of the animation clip (ex: "Run", "Idle", "Jump"). */
   name: string;
-  /** The total duration of the animation clip in seconds. */
-  duration: number;
-  /** The set of channels that make up this animation. */
+  duration: number; // In seconds
   channels: AnimationChannel[];
 }

--- a/src/core/types/gpu.ts
+++ b/src/core/types/gpu.ts
@@ -1,6 +1,7 @@
 // src/core/types/gpu.ts
 import { Mat3, Mat4, Vec3, Vec4 } from "wgpu-matrix";
 import { Material } from "@/core/materials/material";
+import { MaterialInstance } from "../materials/materialInstance";
 
 /**
  * A union of all possible TypedArray constructors that can be used for GPU
@@ -65,7 +66,7 @@ export interface Mesh {
 export interface Renderable {
   mesh: Mesh;
   modelMatrix: Mat4;
-  material: Material;
+  material: MaterialInstance;
   isUniformlyScaled: boolean;
   castShadows?: boolean;
   receiveShadows?: boolean;
@@ -79,15 +80,6 @@ export interface InstanceData {
   isUniformlyScaled: boolean;
   /** Per-instance shadow receiving flag; packed into instance flags bitfield. */
   receiveShadows: boolean;
-}
-
-/**
- * Define a structure to hold all data needed for a batch draw call.
- * A batch is defined by a unique pipeline.
- */
-export interface PipelineBatch {
-  material: Material;
-  meshMap: Map<Mesh, InstanceData[]>;
 }
 
 export interface PBRMaterialOptions {

--- a/src/core/types/rendering.ts
+++ b/src/core/types/rendering.ts
@@ -1,6 +1,6 @@
 // src/core/types/rendering.ts
 import { IBLComponent } from "../ecs/components/iblComponent";
-import { SkyboxMaterial } from "../materials/skyboxMaterial";
+import { MaterialInstance } from "../materials/materialInstance";
 import { Light, Renderable } from "./gpu";
 import { Vec4, vec4 } from "wgpu-matrix";
 
@@ -12,7 +12,7 @@ export class SceneRenderData {
   public renderables: Renderable[] = [];
   public lights: Light[] = [];
   public ambientColor: Vec4 = vec4.create();
-  public skyboxMaterial?: SkyboxMaterial;
+  public skyboxMaterial?: MaterialInstance;
   public iblComponent?: IBLComponent;
   public prefilteredMipLevels = 0;
 

--- a/src/loaders/gltfLoader.ts
+++ b/src/loaders/gltfLoader.ts
@@ -120,9 +120,16 @@ export interface GLTFAnimation {
 
 export interface GLTFAnimationChannel {
   sampler: number; // index into animations.samplers
-  target: {
-    node?: number; // node index
-    path: "translation" | "rotation" | "scale" | "weights";
+  target: GLTFAnimationChannelTarget;
+}
+
+export interface GLTFAnimationChannelTarget {
+  node?: number; // node index
+  path: "translation" | "rotation" | "scale" | "weights";
+  extensions?: {
+    KHR_animation_pointer?: {
+      pointer: string;
+    };
   };
 }
 


### PR DESCRIPTION
Refactors the material system to support per-instance uniform data, enabling animation of material properties like color and roughness.

-   **`Material` / `MaterialInstance` Split:**
    -   `Material` is now a shared template holding the shader, layout, and pipeline cache.
    -   New `MaterialInstance` class holds the per-object uniform buffer and bind group.
    -   `MeshRendererComponent` now uses `MaterialInstance`.

-   **Generalized Animation System:**
    -   `AnimationSystem` is no longer hardcoded to `TransformComponent`.
    -   `AnimationChannel` now uses a generic `path` to target any component and property.
    -   Adds logic to update material uniforms via `MaterialInstance.updateUniform()`.

-   **GLTF Loader Extension:**
    -   Adds support for parsing the `KHR_animation_pointer` extension in glTF files.
    -   Translates JSON Pointers for material properties into the new generic animation channel targets.

This change enables `AnimatedColorsCube.glb` to render correctly, with both its transform and base color animated as specified in the file.