### PR TITLE
Decouple Renderer via RenderContext and Passes

### DIFF
--- a/src/core/rendering/clusterBuilder.ts
+++ b/src/core/rendering/clusterBuilder.ts
@@ -156,7 +156,7 @@ export class ClusterBuilder {
    * Updates the cluster parameters uniform buffer.
    *
    * This method packs camera and viewport data into a uniform buffer that is
-   * used by the compute shaders to correctly assign lights to clusters. It
+   * used by the compute shaders to assign lights to clusters. It
    * should be called every frame before the `record` method.
    *
    * @param camera The camera component.

--- a/src/core/rendering/instanceBufferManager.ts
+++ b/src/core/rendering/instanceBufferManager.ts
@@ -1,0 +1,160 @@
+// src/core/rendering/instanceBufferManager.ts
+import { Renderable } from "@/core/types/gpu";
+import { Renderer } from "@/core/rendering/renderer";
+
+export interface InstanceAllocation {
+  offset: number; // in instances
+  count: number;
+}
+
+export interface InstanceAllocations {
+  shadows: InstanceAllocation;
+  opaques: InstanceAllocation;
+  transparents: InstanceAllocation;
+  total: number;
+}
+
+/**
+ * Manages the allocation, packing, and uploading of per-instance data to a
+ * single GPU buffer for an entire frame.
+ *
+ * This class centralizes instance data handling to ensure a single owner and a
+ * single GPU upload per frame, which is more efficient than multiple writes
+ * from different render passes.
+ */
+export class InstanceBufferManager {
+  private device: GPUDevice;
+  private buffer!: GPUBuffer;
+  private cpuBuffer!: Float32Array;
+  private capacityInInstances = 0; // Current capacity of the buffers
+
+  constructor(device: GPUDevice, initialCapacity = 1024) {
+    this.device = device;
+    this.ensureCapacity(initialCapacity);
+  }
+
+  /**
+   * Returns the underlying GPU buffer.
+   */
+  public getBuffer(): GPUBuffer {
+    return this.buffer;
+  }
+
+  /**
+   * Ensures the CPU and GPU buffers are large enough for the required number of instances.
+   * Recreates buffers if the required capacity exceeds the current capacity.
+   * @param requiredInstances The total number of instances needed for the frame.
+   */
+  private ensureCapacity(requiredInstances: number): void {
+    if (requiredInstances <= this.capacityInInstances) {
+      return;
+    }
+
+    if (this.buffer) {
+      this.buffer.destroy();
+    }
+
+    // Grow capacity with a 1.5x factor to reduce frequent reallocations
+    this.capacityInInstances = Math.ceil(
+      Math.max(requiredInstances, this.capacityInInstances) * 1.5,
+    );
+
+    const newByteSize =
+      this.capacityInInstances * Renderer.INSTANCE_BYTE_STRIDE;
+    this.buffer = this.device.createBuffer({
+      label: "INSTANCE_DATA_BUFFER",
+      size: newByteSize,
+      usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
+    });
+
+    this.cpuBuffer = new Float32Array(
+      this.capacityInInstances * Renderer.INSTANCE_STRIDE_IN_FLOATS,
+    );
+  }
+
+  /**
+   * Packs instance data for a list of renderables into the CPU buffer at a given offset.
+   * @param renderables The list of renderables to pack.
+   * @param instanceOffset The starting offset in the CPU buffer (in instances).
+   */
+  private packGroup(renderables: Renderable[], instanceOffset: number): void {
+    const u32View = new Uint32Array(this.cpuBuffer.buffer);
+
+    for (let i = 0; i < renderables.length; i++) {
+      const renderable = renderables[i];
+      const floatOffset =
+        (instanceOffset + i) * Renderer.INSTANCE_STRIDE_IN_FLOATS;
+
+      // Pack model matrix (16 floats)
+      this.cpuBuffer.set(renderable.modelMatrix, floatOffset);
+
+      // Pack flags (u32)
+      const flags =
+        (renderable.isUniformlyScaled ? 1 : 0) |
+        ((renderable.receiveShadows !== false ? 1 : 0) << 1);
+      u32View[floatOffset + 16] = flags;
+    }
+  }
+
+  /**
+   * Packs all instance data for the frame from categorized renderable lists
+   * into a single CPU-side buffer and then uploads it to the GPU in one operation.
+   *
+   * @param shadows A list of renderables that cast shadows.
+   * @param opaques A list of opaque renderables.
+   * @param transparents A list of transparent renderables.
+   * @returns An object containing the offset and count for each category.
+   */
+  public packAndUpload(
+    shadows: Renderable[],
+    opaques: Renderable[],
+    transparents: Renderable[],
+  ): InstanceAllocations {
+    const totalInstances =
+      shadows.length + opaques.length + transparents.length;
+    this.ensureCapacity(totalInstances);
+
+    let currentOffset = 0;
+
+    // Pack shadows
+    this.packGroup(shadows, currentOffset);
+    const shadowAlloc: InstanceAllocation = {
+      offset: currentOffset,
+      count: shadows.length,
+    };
+    currentOffset += shadows.length;
+
+    // Pack opaques
+    this.packGroup(opaques, currentOffset);
+    const opaqueAlloc: InstanceAllocation = {
+      offset: currentOffset,
+      count: opaques.length,
+    };
+    currentOffset += opaques.length;
+
+    // Pack transparents
+    this.packGroup(transparents, currentOffset);
+    const transparentAlloc: InstanceAllocation = {
+      offset: currentOffset,
+      count: transparents.length,
+    };
+
+    // Perform a single upload to the GPU
+    if (totalInstances > 0) {
+      this.device.queue.writeBuffer(
+        this.buffer,
+        0,
+        this.cpuBuffer.buffer,
+        0,
+        totalInstances * Renderer.INSTANCE_BYTE_STRIDE,
+      );
+    }
+
+    return {
+      shadows: shadowAlloc,
+      opaques: opaqueAlloc,
+      transparents: transparentAlloc,
+      total: totalInstances,
+    };
+  }
+}

--- a/src/core/rendering/passes/clusterPass.ts
+++ b/src/core/rendering/passes/clusterPass.ts
@@ -1,12 +1,37 @@
 // src/core/rendering/passes/clusterPass.ts
 import { ClusterBuilder } from "@/core/rendering/clusterBuilder";
 import { RendererStats } from "@/core/types/renderer";
-import { CameraComponent } from "@/core/ecs/components/cameraComponent";
+import { RenderContext, RenderPass } from "@/core/types/rendering";
 
-export class ClusterPass {
+/**
+ * Manages the clustered forward rendering compute passes.
+ *
+ * @remarks
+ * This pass is responsible for orchestrating the `ClusterBuilder`, which
+ * executes compute shaders to assign lights to a 3D grid of clusters in view
+ * space. It does not render any geometry itself but prepares the light culling
+ * data structures on the GPU that are consumed by the main PBR shader.
+ *
+ * The assignment shader (`cluster.wgsl`) operates by projecting each light's
+ * bounding sphere into view space to determine the range of X, Y, and Z
+ * clusters it overlaps. It then uses atomic operations to append the light's
+ * index to the lists for all overlapped clusters, allowing for safe parallel
+ * execution on the GPU. This culling process dramatically reduces the number of
+ * light calculations required in the main PBR fragment shader.
+ *
+ * The pass's primary responsibilities within the frame are:
+ * 1. Updating the cluster grid parameters based on the current camera and viewport.
+ * 2. Recording the compute shader dispatches to clear old light lists and
+ *    assign current lights to clusters.
+ * 3. Periodically reading back cluster statistics for performance monitoring.
+ */
+export class ClusterPass implements RenderPass {
   private device: GPUDevice;
   private clusterBuilder: ClusterBuilder;
 
+  /**
+   * @param device The active GPUDevice.
+   */
   constructor(device: GPUDevice) {
     this.device = device;
     this.clusterBuilder = new ClusterBuilder(this.device, {
@@ -17,27 +42,63 @@ export class ClusterPass {
     });
   }
 
+  /**
+   * Initializes the pass by creating the underlying ClusterBuilder and its
+   * associated GPU resources, such as compute pipelines and buffers.
+   *
+   * @remarks
+   * This must be called before the pass can be executed.
+   */
   public async init(): Promise<void> {
     await this.clusterBuilder.init();
   }
 
+  /**
+   * Retrieves the underlying ClusterBuilder instance.
+   *
+   * @remarks
+   * This allows the Renderer to access the cluster buffers, which are required
+   * for the main frame bind group.
+   *
+   * @returns The ClusterBuilder instance managed by this pass.
+   */
   public getClusterBuilder(): ClusterBuilder {
     return this.clusterBuilder;
   }
 
-  public record(
-    commandEncoder: GPUCommandEncoder,
-    lightCount: number,
-    camera: CameraComponent,
-    canvasWidth: number,
-    canvasHeight: number,
-    lightStorageBuffer: GPUBuffer,
-  ): void {
-    this.clusterBuilder.updateParams(camera, canvasWidth, canvasHeight);
+  /**
+   * Executes the light clustering compute passes for the frame.
+   *
+   * @remarks
+   * This method pulls the necessary information from the `RenderContext`, such
+   * as the camera and light data, and directs the `ClusterBuilder` to record
+   * its compute commands into the context's command encoder.
+   *
+   * @param context The immutable render context for the current frame.
+   */
+  public execute(context: RenderContext): void {
+    const lightCount = context.sceneData.lights.length;
+    const lightStorageBuffer = context.lightStorageBuffer;
+
+    this.clusterBuilder.updateParams(
+      context.camera,
+      context.canvasWidth,
+      context.canvasHeight,
+    );
     this.clusterBuilder.createComputeBindGroup(lightStorageBuffer);
-    this.clusterBuilder.record(commandEncoder, lightCount);
+    this.clusterBuilder.record(context.commandEncoder, lightCount);
   }
 
+  /**
+   * Updates the provided renderer statistics object with the latest data from
+   * the cluster readback.
+   *
+   * @remarks
+   * The statistics are read from the GPU periodically, so they may not be
+   * updated every single frame.
+   *
+   * @param stats The renderer statistics object to populate.
+   */
   public updateStats(stats: RendererStats): void {
     const cls = this.clusterBuilder.getLastStats();
     stats.clusterAvgLpcX1000 = cls.avgLpcX1000;
@@ -45,6 +106,14 @@ export class ClusterPass {
     stats.clusterOverflows = cls.overflow;
   }
 
+  /**
+   * Notifies the underlying ClusterBuilder that the frame's command buffers
+   * have been submitted.
+   *
+   * @remarks
+   * This is a necessary step to trigger the asynchronous readback of cluster
+   * statistics from the GPU without stalling the pipeline.
+   */
   public onSubmitted(): void {
     this.clusterBuilder.onSubmitted();
   }

--- a/src/core/rendering/passes/shadowPass.ts
+++ b/src/core/rendering/passes/shadowPass.ts
@@ -1,22 +1,52 @@
 // src/core/rendering/passes/shadowPass.ts
 import { ShadowSubsystem } from "@/core/rendering/shadow";
 import { Renderer } from "@/core/rendering/renderer";
-import { Renderable } from "@/core/types/gpu";
 import {
   SceneSunComponent,
   ShadowSettingsComponent,
 } from "@/core/ecs/components/sunComponent";
 import { CameraComponent } from "@/core/ecs/components/cameraComponent";
+import { RenderContext, RenderPass } from "@/core/types/rendering";
 
-export class ShadowPass {
+/**
+ * Manages the generation of the cascaded shadow map (CSM) for the main sun.
+ *
+ * @remarks
+ * This pass is responsible for rendering the scene from the sun's perspective
+ * into a depth texture array. It is a depth-only pass and does not produce any
+ * color output.
+ *
+ * The process is executed in a loop, once for each of the four shadow cascades.
+ * For each cascade, it configures a render pass targeting a specific layer of
+ * the shadow map texture array. The vertex shader (`shadow.wgsl`) then
+ * transforms each shadow-casting object's vertices using its model matrix and
+ * the unique view-projection matrix for that specific cascade. The GPU's
+ * rasterizer then writes the resulting depth values to the shadow map.
+ *
+ * The resulting depth texture array is later sampled by the main PBR shader
+ * to apply shadows to the scene.
+ */
+export class ShadowPass implements RenderPass {
   private device: GPUDevice;
   private shadowSubsystem: ShadowSubsystem;
 
+  /**
+   * @param device The active GPUDevice.
+   */
   constructor(device: GPUDevice) {
     this.device = device;
     this.shadowSubsystem = new ShadowSubsystem(this.device);
   }
 
+  /**
+   * Initializes the pass and its underlying `ShadowSubsystem`.
+   *
+   * @remarks
+   * This method sets up the necessary GPU resources, including the shadow map
+   * texture array, comparison sampler, and the specialized depth-only render
+   * pipeline used to draw shadow casters. It must be called before the pass
+   * can be executed.
+   */
   public async init(): Promise<void> {
     await this.shadowSubsystem.init(
       [
@@ -51,10 +81,32 @@ export class ShadowPass {
     );
   }
 
+  /**
+   * Retrieves the underlying `ShadowSubsystem` instance.
+   *
+   * @remarks
+   * This provides access to the shadow map resources (texture view, sampler,
+   * and uniform buffer) which are required by the `Renderer` to construct the
+   * main frame bind group.
+   *
+   * @returns The `ShadowSubsystem` managed by this pass.
+   */
   public getShadowSubsystem(): ShadowSubsystem {
     return this.shadowSubsystem;
   }
 
+  /**
+   * Updates the shadow subsystem's per-frame uniforms, such as the CSM matrices.
+   *
+   * @remarks
+   * This method is called internally by `execute`. It computes the view and
+   * projection matrices for each cascade based on the main camera's frustum
+   * and the sun's direction.
+   *
+   * @param camera The main scene camera.
+   * @param sun The scene's directional sun component.
+   * @param shadowSettings The current shadow quality settings.
+   */
   public updatePerFrame(
     camera: CameraComponent,
     sun?: SceneSunComponent,
@@ -67,41 +119,51 @@ export class ShadowPass {
     }
   }
 
-  public record(
-    commandEncoder: GPUCommandEncoder,
-    shadowCasters: Renderable[],
-    shadowSettings: ShadowSettingsComponent,
-    instanceBuffer: GPUBuffer,
-    frameInstanceData: Float32Array,
-  ): void {
-    const shadowCasterCount = shadowCasters.length;
-    if (shadowCasterCount === 0) {
+  /**
+   * Executes the shadow map generation for the frame.
+   *
+   * @remarks
+   * This is the main entry point for the pass. It performs the following steps:
+   * 1. Updates the CSM uniforms by calling `updatePerFrame`.
+   * 2. Filters the *entire* scene's renderables to find all potential shadow
+   *    casters. It does not use the pre-culled visible list, allowing objects
+   *    outside the camera's view to cast shadows into it.
+   * 3. Records a series of depth-only render passes, one for each cascade,
+   *    drawing all shadow casters into the appropriate layer of the shadow map.
+   *
+   * @param context The immutable render context for the current frame.
+   */
+  public execute(context: RenderContext): void {
+    const { sun, shadowSettings } = context;
+
+    // The pass is responsible for updating its own subsystem's uniforms.
+    this.updatePerFrame(context.camera, sun, shadowSettings);
+
+    if (!sun || !sun.enabled || !sun.castsShadows || !shadowSettings) {
       return;
     }
 
-    const floatsPerInstance = Renderer.INSTANCE_STRIDE_IN_FLOATS;
-    const u32 = new Uint32Array(frameInstanceData.buffer);
-    for (let i = 0; i < shadowCasterCount; i++) {
-      const floatOffset = i * floatsPerInstance;
-      frameInstanceData.set(shadowCasters[i].modelMatrix, floatOffset);
-      const flags =
-        (shadowCasters[i].isUniformlyScaled ? 1 : 0) |
-        ((shadowCasters[i].receiveShadows !== false ? 1 : 0) << 1);
-      u32[floatOffset + 16] = flags;
-    }
-    this.device.queue.writeBuffer(
-      instanceBuffer,
-      0,
-      frameInstanceData.buffer,
-      0,
-      shadowCasterCount * Renderer.INSTANCE_BYTE_STRIDE,
+    // The pass filters its own data from the full scene list.
+    // This allows objects outside the camera view to cast shadows.
+    const shadowCasters = context.sceneData.renderables.filter(
+      (r) => r.castShadows !== false && !r.material.material.isTransparent,
     );
 
+    if (shadowCasters.length === 0) {
+      return;
+    }
+
+    // The instance data is already on the GPU. We just need the offset.
+    const instanceByteOffset =
+      context.instanceAllocations.shadows.offset *
+      Renderer.INSTANCE_BYTE_STRIDE;
+
     this.shadowSubsystem.recordShadowPass(
-      commandEncoder,
+      context.commandEncoder,
       shadowSettings.mapSize,
       shadowCasters,
-      instanceBuffer,
+      context.instanceBuffer,
+      instanceByteOffset,
     );
   }
 }

--- a/src/core/rendering/passes/skyboxPass.ts
+++ b/src/core/rendering/passes/skyboxPass.ts
@@ -1,21 +1,58 @@
 // src/core/rendering/passes/skyboxPass.ts
-import { MaterialInstance } from "@/core/materials/materialInstance";
 import { Renderer } from "@/core/rendering/renderer";
+import { RenderContext, RenderPass } from "@/core/types/rendering";
 
-export class SkyboxPass {
-  public record(
+/**
+ * Renders the scene's skybox.
+ *
+ * @remarks
+ * This pass is responsible for drawing the environment cubemap behind all other
+ * geometry. It employs a highly optimized technique that avoids the need for
+ * any vertex buffers.
+ *
+ * The rendering process works as follows:
+ * 1. A single draw call renders three vertices, which the vertex shader
+ *    procedurally expands into a single triangle that covers the entire viewport.
+ * 2. The vertex shader calculates the world-space view direction for each pixel
+ *    by unprojecting the screen coordinates using the camera's inverse
+ *    view-projection matrix. This ensures the skybox correctly rotates with the camera.
+ * 3. Crucially, the vertex shader outputs a clip-space Z value of 1.0, placing
+ *    the skybox exactly at the far clipping plane.
+ * 4. When the render pipeline uses a `less-equal` depth comparison, this
+ *    technique guarantees that the skybox is only drawn on pixels where no
+ *    closer scene geometry exists, effectively making it an efficient background
+ *    fill.
+ * 5. The fragment shader simply samples the skybox cubemap texture using the
+ *    calculated view direction.
+ */
+export class SkyboxPass implements RenderPass {
+  /**
+   * Executes the skybox rendering pass.
+   *
+   * @remarks
+   * This method retrieves the skybox material from the `RenderContext`. If one
+   * exists, it sets up the appropriate render pipeline and issues a single
+   * draw call to render the skybox into the provided render pass encoder.
+   *
+   * @param context The immutable render context for the current frame.
+   * @param passEncoder The `GPURenderPassEncoder` for the main scene pass,
+   *   into which the skybox will be drawn.
+   */
+  public execute(
+    context: RenderContext,
     passEncoder: GPURenderPassEncoder,
-    skyboxMaterial: MaterialInstance,
-    frameBindGroupLayout: GPUBindGroupLayout,
-    canvasFormat: GPUTextureFormat,
-    depthFormat: GPUTextureFormat,
   ): void {
+    const skyboxMaterial = context.sceneData.skyboxMaterial;
+    if (!skyboxMaterial) {
+      return;
+    }
+
     const pipeline = skyboxMaterial.material.getPipeline(
       [],
       Renderer.INSTANCE_DATA_LAYOUT,
-      frameBindGroupLayout,
-      canvasFormat,
-      depthFormat,
+      context.frameBindGroupLayout,
+      context.canvasFormat,
+      context.depthFormat,
     );
     passEncoder.setPipeline(pipeline);
     passEncoder.setBindGroup(1, skyboxMaterial.bindGroup);

--- a/src/core/rendering/passes/uiPass.ts
+++ b/src/core/rendering/passes/uiPass.ts
@@ -1,6 +1,38 @@
 // src/core/rendering/passes/uiPass.ts
 
+/**
+ * A utility class for rendering UI or other overlays on top of a completed scene.
+ *
+ * @remarks
+ * This class is not a standard `RenderPass` because it serves a special purpose.
+ * Its primary function is to create a `GPURenderPass` configured with
+ * `loadOp: 'load'`. This setting is crucial as it preserves the existing
+ * contents of the color attachment (the rendered scene) instead of clearing it,
+ * allowing the UI to be drawn directly on top.
+ *
+ * It acts as a simple wrapper that handles the boilerplate of beginning and
+ * ending the render pass, and then delegates the actual drawing commands to a
+ * callback function provided by the caller. This makes it easy to integrate
+ * external UI libraries or custom debug drawing.
+ */
 export class UIPass {
+  /**
+   * Records a render pass for drawing UI.
+   *
+   * @remarks
+   * This method begins a new render pass, sets the viewport to the full
+   * canvas size, invokes the provided `callback` with the pass encoder, and
+   * then immediately ends the pass.
+   *
+   * @param commandEncoder The `GPUCommandEncoder` for the current frame.
+   * @param textureView The `GPUTextureView` to render into, typically the
+   *   canvas's current texture view.
+   * @param canvasWidth The physical width of the target texture view.
+   * @param canvasHeight The physical height of the target texture view.
+   * @param callback A function that receives the configured
+   *   `GPURenderPassEncoder`. The caller is responsible for recording all UI
+   *   drawing commands within this function.
+   */
   public record(
     commandEncoder: GPUCommandEncoder,
     textureView: GPUTextureView,

--- a/src/core/rendering/shadow.ts
+++ b/src/core/rendering/shadow.ts
@@ -485,6 +485,7 @@ export class ShadowSubsystem {
     mapSize: number,
     renderables: Renderable[],
     instanceBuffer: GPUBuffer,
+    instanceByteOffset: number,
   ): void {
     if (!this.pipeline || renderables.length === 0) {
       return;
@@ -530,14 +531,11 @@ export class ShadowSubsystem {
         pass.setVertexBuffer(
           mesh.layouts.length,
           instanceBuffer,
-          drawnCount * this.instanceByteStride,
+          instanceByteOffset + drawnCount * this.instanceByteStride,
         );
 
         if (mesh.indexBuffer) {
-          pass.setIndexBuffer(
-            mesh.indexBuffer,
-            mesh.indexFormat ?? "uint32",
-          );
+          pass.setIndexBuffer(mesh.indexBuffer, mesh.indexFormat ?? "uint32");
           pass.drawIndexed(mesh.indexCount ?? 0, count, 0, 0, 0);
         } else {
           pass.draw(mesh.vertexCount, count, 0, 0);

--- a/src/core/types/rendering.ts
+++ b/src/core/types/rendering.ts
@@ -13,12 +13,30 @@ import { Light, Renderable } from "@/core/types/gpu";
 import { vec4, Vec4 } from "wgpu-matrix";
 
 /**
+ * An interface representing the data properties of the scene to be rendered.
+ * This is used in the RenderContext to provide an immutable snapshot of the scene data.
+ */
+export interface ISceneRenderData {
+  readonly renderables: readonly Renderable[];
+  readonly lights: readonly Light[];
+  readonly skyboxMaterial?: MaterialInstance;
+  readonly iblComponent?: IBLComponent;
+  readonly prefilteredMipLevels: number;
+  readonly fogEnabled: boolean;
+  readonly fogColor: Vec4;
+  readonly fogDensity: number;
+  readonly fogHeight: number;
+  readonly fogHeightFalloff: number;
+  readonly fogInscatteringIntensity: number;
+}
+
+/**
  * A context object containing all necessary data and resources for a single
  * frame's render passes. It is passed immutably to each pass's `execute` method.
  */
 export interface RenderContext {
   // Immutable scene data for the frame
-  readonly sceneData: SceneRenderData;
+  readonly sceneData: ISceneRenderData;
   readonly camera: CameraComponent;
   readonly sun?: SceneSunComponent;
   readonly shadowSettings?: ShadowSettingsComponent;
@@ -34,6 +52,7 @@ export interface RenderContext {
   // Shared frame resources
   readonly frameBindGroup: GPUBindGroup;
   readonly frameBindGroupLayout: GPUBindGroupLayout;
+  readonly lightStorageBuffer: GPUBuffer;
 
   // Instance data (prepared once per frame)
   readonly instanceBuffer: GPUBuffer;
@@ -64,7 +83,7 @@ export interface RenderPass {
  * A container for all the data required by the Renderer to render a single frame.
  * This is a class with pre-allocated arrays to avoid GC pressure.
  */
-export class SceneRenderData {
+export class SceneRenderData implements ISceneRenderData {
   public renderables: Renderable[] = [];
   public lights: Light[] = [];
   public skyboxMaterial?: MaterialInstance;
@@ -86,6 +105,5 @@ export class SceneRenderData {
     this.iblComponent = undefined;
     this.prefilteredMipLevels = 0;
     this.fogEnabled = false; // Reset per frame
-    // Default fog params remain
   }
 }


### PR DESCRIPTION
- New `RenderContext` immutable object acting as single source of truth for all frame data passed to passes
- New `InstanceBufferManager` class with exclusive ownership of the instance buffer
- Self-contained render passes, pulling data from `RenderContext`
- Move ownership of `BatchManager` to `OpaquePass`
- Simpler `Renderer` class
- New `ISceneRenderData` to decouple `RenderContext` from `SceneRenderData`
- Code cleanup and updated TsDoc